### PR TITLE
Implement constructor mapping

### DIFF
--- a/Benchmark.linq
+++ b/Benchmark.linq
@@ -1,0 +1,103 @@
+<Query Kind="Program">
+  <Reference Relative="MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll">E:\Src\MAB.SimpleMapper\MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll</Reference>
+  <Namespace>MAB.SimpleMapper</Namespace>
+</Query>
+
+void Main()
+{
+    Mapper.ClearMappings();
+
+    var entities = GetEntities(1000);
+
+    var results = new List<Model>();
+
+    var result1 = Benchmark.Perform(() => {
+        foreach (var entity in entities)
+        {
+            // var model = new Model();
+            // entity.MapTo(model);
+            var model = entity.MapTo<Model>();
+            results.Add(model);
+        }
+    });
+
+    Mapper.ClearMappings();
+    Mapper.UseCustomDelegate = true;
+
+    var results2 = new List<Model>();
+
+    var result2 = Benchmark.Perform(() => {
+        foreach (var entity in entities)
+        {
+//            var model = new Model();
+//            entity.MapTo(model);
+            var model = entity.MapTo<Model>();
+            results2.Add(model);
+        }
+    });
+
+    result1.Dump("Activator.CreateInstance");
+
+    results.Take(10).Dump();
+
+    result2.Dump("Cached Delegate");
+
+    results.Take(10).Dump();
+    
+    Mapper._activators.Dump();
+}
+
+public IEnumerable<Entity> GetEntities(int count)
+{
+    var rnd = new Random();
+
+    for (var i = 0; i < count; i++)
+    {
+        var email = new String(Enumerable.Range(1, 5).Select(x => (char)rnd.Next(66, 91)).ToArray())
+                  + "@" + new String(Enumerable.Range(1, 10).Select(x => (char)rnd.Next(66, 91)).ToArray())
+                  + "." + new String(Enumerable.Range(1, 3).Select(x => (char)rnd.Next(66, 91)).ToArray());
+
+        yield return new Entity
+        {
+            ID = rnd.Next(1, 500),
+            Email = email.ToLower(),
+            Created = DateTime.Now.AddDays((rnd.Next(1, 10000) * -1)),
+            Active = (rnd.Next(1, 100) > 50)
+        };
+    }
+}
+
+public class Entity 
+{
+    public int ID { get; set; }
+    public string Email { get; set; }
+    public DateTime Created { get; set; }
+    public bool Active { get; set; }
+}
+
+public class Model 
+{
+    public int ID { get; set; }
+    public string Email { get; set; }
+    public DateTime Created { get; set; }
+    public bool Active { get; set; }
+}
+
+public class Benchmark 
+{
+    public static long Perform(Action action)
+	{
+		return Benchmark.Perform(action, 1);
+	}
+
+	public static long Perform(Action action, int iterations)
+	{
+		var stopwatch = Stopwatch.StartNew();
+		for (int i = 0; i < iterations; i++)
+		{
+			action();
+		}
+		stopwatch.Stop();
+		return stopwatch.ElapsedMilliseconds;
+	}
+}

--- a/Benchmark.linq
+++ b/Benchmark.linq
@@ -1,50 +1,45 @@
 <Query Kind="Program">
-  <Reference Relative="MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll">E:\Src\MAB.SimpleMapper\MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll</Reference>
+  <Reference Relative="MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll">C:\Src\MAB.SimpleMapper\MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll</Reference>
   <Namespace>MAB.SimpleMapper</Namespace>
 </Query>
 
 void Main()
 {
+    // Cha
+    
     Mapper.ClearMappings();
 
-    var entities = GetEntities(1000);
+    var entities = GetEntities(10000);
 
     var results = new List<Model>();
 
     var result1 = Benchmark.Perform(() => {
         foreach (var entity in entities)
         {
-            // var model = new Model();
-            // entity.MapTo(model);
-            var model = entity.MapTo<Model>();
+            var model = entity.MapToConstructorCreateInstance<Model>();
             results.Add(model);
         }
     });
 
     Mapper.ClearMappings();
-    Mapper.UseCustomDelegate = true;
 
     var results2 = new List<Model>();
 
     var result2 = Benchmark.Perform(() => {
         foreach (var entity in entities)
         {
-//            var model = new Model();
-//            entity.MapTo(model);
-            var model = entity.MapTo<Model>();
+            var model = entity.MapToConstructorCustomDelegate<Model>();
             results2.Add(model);
         }
     });
 
-    result1.Dump("Activator.CreateInstance");
+    result1.Dump("MapToConstructorCreateInstance");
 
     results.Take(10).Dump();
 
-    result2.Dump("Cached Delegate");
+    result2.Dump("MapToConstructorCustomDelegate");
 
     results.Take(10).Dump();
-    
-    Mapper._activators.Dump();
 }
 
 public IEnumerable<Entity> GetEntities(int count)
@@ -77,10 +72,18 @@ public class Entity
 
 public class Model 
 {
-    public int ID { get; set; }
-    public string Email { get; set; }
-    public DateTime Created { get; set; }
-    public bool Active { get; set; }
+    public int ID { get; private set; }
+    public string Email { get; private set; }
+    public DateTime Created { get; private set; }
+    public bool Active { get; private set; }
+    
+    public Model(int id, string email, DateTime created, bool active)
+    {
+        ID = id;
+        Email = email;
+        Created = created;
+        Active = active;
+    }
 }
 
 public class Benchmark 

--- a/MAB.SimpleMapper.Test/EntityConstructorOnly.cs
+++ b/MAB.SimpleMapper.Test/EntityConstructorOnly.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MAB.SimpleMapper.Test
+{
+    public class EntityConstructorOnly
+    {
+        public int ID { get; private set; }
+        public string Email { get; private set; }
+
+        public EntityConstructorOnly(int id, string email)
+        {
+            ID = id;
+            Email = email;
+        }
+    }
+}

--- a/MAB.SimpleMapper.Test/MAB.SimpleMapper.Test.csproj
+++ b/MAB.SimpleMapper.Test/MAB.SimpleMapper.Test.csproj
@@ -62,6 +62,8 @@
   <ItemGroup>
     <Compile Include="Entity.cs" />
     <Compile Include="Entity2.cs" />
+    <Compile Include="ModelConstructorOnly.cs" />
+    <Compile Include="EntityConstructorOnly.cs" />
     <Compile Include="EntityEnum.cs" />
     <Compile Include="EntityPrivateProperties.cs" />
     <Compile Include="Extensions.cs" />

--- a/MAB.SimpleMapper.Test/ModelConstructorOnly.cs
+++ b/MAB.SimpleMapper.Test/ModelConstructorOnly.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MAB.SimpleMapper.Test
+{
+    public class ModelConstructorOnly
+    {
+        public int ID { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/MAB.SimpleMapper.Test/Tests.cs
+++ b/MAB.SimpleMapper.Test/Tests.cs
@@ -931,5 +931,57 @@ namespace MAB.SimpleMapper.Test
             models[1].Name.ShouldEqual("Jane Test");
             models[1].Email.ShouldEqual("jane@test.com");
         }
+
+        [Test]
+        public void Map_NULL_Object_To_New_Constructor()
+        {
+            ModelConstructorOnly model = null;
+
+            var entity = model.MapToConstructor<EntityConstructorOnly>();
+
+            model.ShouldEqual(null);
+        }
+
+        [Test]
+        public void Map_Object_To_New_Constructor_Exact_Arguments()
+        {
+            var model = new {
+                ID = 100,
+                Email = "test@test.com"
+            };
+
+            var entity = model.MapToConstructor<EntityConstructorOnly>();
+
+            entity.ID.ShouldEqual(100);
+            entity.Email.ShouldEqual("test@test.com");
+        }
+
+        [Test]
+        public void Map_Object_To_New_Constructor_More_Arguments()
+        {
+            var model = new {
+                Name = "TEST NAME",
+                ID = 100,
+                Email = "test@test.com"
+            };
+
+            var entity = model.MapToConstructor<EntityConstructorOnly>();
+
+            entity.ID.ShouldEqual(100);
+            entity.Email.ShouldEqual("test@test.com");
+        }
+
+        [Test]
+        public void Map_Object_To_New_Constructor_Less_Arguments()
+        {
+            var model = new {
+                Email = "test@test.com"
+            };
+
+            var entity = model.MapToConstructor<EntityConstructorOnly>();
+
+            entity.ID.ShouldEqual(0);
+            entity.Email.ShouldEqual("test@test.com");
+        }
     }
 }

--- a/MAB.SimpleMapper/Properties/AssemblyInfo.cs
+++ b/MAB.SimpleMapper/Properties/AssemblyInfo.cs
@@ -22,6 +22,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("2f830b31-805d-43d9-b2b6-d2f16f94d59a")]
 
+// Allow access to internal methods from LINQPad (for benchmarking)
+[assembly: InternalsVisibleTo("LINQPadQuery")]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version

--- a/Test Harness.linq
+++ b/Test Harness.linq
@@ -1,0 +1,141 @@
+<Query Kind="Program">
+  <Reference Relative="MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll">E:\Src\MAB.SimpleMapper\MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll</Reference>
+  <Namespace>MAB.SimpleMapper</Namespace>
+  <Namespace>System.Collections.Concurrent</Namespace>
+</Query>
+
+void Main()
+{
+    var tmp = new {
+        ID = 100,
+        Email = "test@test.com"
+    };
+
+    var tc1 = tmp.TUseToConstruct2<TestClass>();
+    tc1.Dump();
+    
+    var tc2 = tmp.TUseToConstruct2<TestClass>();
+    tc2.Dump();
+}
+
+public class TestClass 
+{
+//    public TestClass() {}
+//
+//    public TestClass(int id, string email)
+//    {
+//        ID = id;
+//        Email = email;
+//    }
+
+    public TestClass(int id, string name, string email)
+    {
+        ID = id;
+        Name = name;
+        Email = email;
+    }
+
+    public TestClass(int id, string name, string email, string other)
+    {
+        ID = id;
+        Name = name;
+        Email = email;
+        Other = other;
+    }
+
+    public int ID { get; private set; }
+    public string Name { get; private set; }
+    public string Email { get; private set; }
+    public string Other { get; private set; }
+}
+
+public static class Extensions 
+{
+    public static TDestination TUseToConstruct<TDestination>(this object source) where TDestination : class
+    {
+        var sourceProperties = source.GetType().GetProperties().Select(p => p.GetValue(source)).ToArray();
+        
+        return (TDestination)Activator.CreateInstance(typeof(TDestination), sourceProperties);   
+    }
+
+    public static TDestination TUseToConstruct2<TDestination>(this object source) where TDestination: class
+    {
+        // Get all the constructors for the destination type
+        var constructors = typeof(TDestination).GetConstructors();
+        
+        var constructorSignatures = new Dictionary<ConstructorInfo, IEnumerable<string>>();
+        
+        // For each constructor on this type, add a dictionary entry where the constructor itself is the key, and the 
+        // value is a list of the parameters for the constructor, converted to strings in the form PROPNAME~TYPENAME
+        foreach (var constructor in constructors)
+        {
+            var constructorSignature = constructor.GetParameters().Select(p => string.Format("{0}~{1}", GetNormalisedPropertyName(p.Name), p.ParameterType));
+            
+            constructorSignatures.Add(constructor, constructorSignature);
+        }
+        
+        // Now we do the same with all the properties of the source type
+        var sourceProperties = source.GetType().GetProperties();
+
+        var sourcePropertySignature = sourceProperties.Select(p => string.Format("{0}~{1}", GetNormalisedPropertyName(p.Name), p.PropertyType));
+
+        // This dictionary will hold a number telling us how different each constructor signature
+        var rankedConstructorSignatures = new List<Tuple<ConstructorInfo, int>>();
+
+        // Loop over each constructor signature and find the one which matches the most source type properties, by intersecting
+        // the array of property signatures for each constructor with the property signature of the current source object
+        foreach (var k in constructorSignatures.Keys)
+            rankedConstructorSignatures.Add(new Tuple<ConstructorInfo, int>(k, sourcePropertySignature.Intersect(constructorSignatures[k]).Count()));
+        
+        // Pick the constructor with the largest intersection with the source type's properties
+        var bestConstructor = rankedConstructorSignatures.OrderByDescending(x => x.Item2).First().Item1;
+        
+        // Create a delegate which will construct on object of the new type using the best matching constructor
+        // TODO: We can also cache this in memory to improve performance
+        var createObject = CreateObject<TDestination>(bestConstructor);
+        
+        Func<PropertyInfo, ParameterInfo, bool> find = (sp, p) => GetNormalisedPropertyName(sp.Name) == GetNormalisedPropertyName(p.Name) && sp.PropertyType == p.ParameterType;
+        
+        var args = bestConstructor.GetParameters().Select(p => sourceProperties.FirstOrDefault(sp => find(sp, p))?.GetValue(source)).ToArray(); 
+        
+        return createObject(args);
+    }
+
+    private delegate T CreateT<T>(params object[] args);
+
+    private static CreateT<T> CreateObject<T>(ConstructorInfo ctor)
+    {
+        var type = ctor.DeclaringType;
+        var ctorParams = ctor.GetParameters();
+
+        //create a single param of type object[]
+        var args = Expression.Parameter(typeof(object[]), "args");
+
+        var argsExp = new Expression[ctorParams.Length];
+
+        //pick each arg from the params array 
+        //and create a typed expression of them
+        for (int i = 0; i < ctorParams.Length; i++)
+        {
+            argsExp[i] = Expression.Convert(
+                Expression.ArrayIndex(args, Expression.Constant(i)),
+                ctorParams[i].ParameterType
+            );
+        }
+
+        //make a NewExpression that calls the
+        //ctor with the args we just created
+        var newExp = Expression.New(ctor, argsExp);
+
+        //create a lambda with the New
+        //Expression as body and our param object[] as arg
+        var lambda = Expression.Lambda(typeof(CreateT<T>), newExp, args);
+
+        return (CreateT<T>)lambda.Compile();
+    }
+
+    private static string GetNormalisedPropertyName(string propertyName)
+    {
+        return Regex.Replace(propertyName.ToUpperInvariant(), "_", "");
+    }
+}

--- a/Test Harness.linq
+++ b/Test Harness.linq
@@ -1,5 +1,5 @@
 <Query Kind="Program">
-  <Reference Relative="MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll">E:\Src\MAB.SimpleMapper\MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll</Reference>
+  <Reference Relative="MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll">C:\Src\MAB.SimpleMapper\MAB.SimpleMapper\bin\Debug\MAB.SimpleMapper.dll</Reference>
   <Namespace>MAB.SimpleMapper</Namespace>
   <Namespace>System.Collections.Concurrent</Namespace>
 </Query>
@@ -7,35 +7,70 @@
 void Main()
 {
     var tmp = new {
+        Email = "test@test.com",
         ID = 100,
-        Email = "test@test.com"
+        NotAParam = true
     };
 
-    var tc1 = tmp.TUseToConstruct2<TestClass>();
-    tc1.Dump();
-    
-    var tc2 = tmp.TUseToConstruct2<TestClass>();
-    tc2.Dump();
+    tmp.MapToConstructor<TestClass1>().Dump();
+    tmp.MapToConstructor<TestClass2>().Dump();
+    tmp.MapToConstructor<TestClass3>().Dump();
+    tmp.MapToConstructor<TestClass4>().Dump();
 }
 
-public class TestClass 
+public class TestClass1
 {
-//    public TestClass() {}
-//
-//    public TestClass(int id, string email)
-//    {
-//        ID = id;
-//        Email = email;
-//    }
+    public TestClass1() {}
 
-    public TestClass(int id, string name, string email)
+    public TestClass1(int id)
+    {
+        ID = id;
+    }
+    
+    public int ID { get; private set; }
+    public string Name { get; private set; }
+    public string Email { get; private set; }
+    public string Other { get; private set; }
+}
+
+public class TestClass2
+{
+    public TestClass2() {}
+
+    public TestClass2(int id, string email)
+    {
+        ID = id;
+        Email = email;
+    }
+    
+    public int ID { get; private set; }
+    public string Name { get; private set; }
+    public string Email { get; private set; }
+    public string Other { get; private set; }
+}
+
+public class TestClass3
+{
+    public TestClass3() {}
+
+    public TestClass3(int id, string name, string email)
     {
         ID = id;
         Name = name;
         Email = email;
     }
 
-    public TestClass(int id, string name, string email, string other)
+    public int ID { get; private set; }
+    public string Name { get; private set; }
+    public string Email { get; private set; }
+    public string Other { get; private set; }
+}
+
+public class TestClass4
+{
+    public TestClass4() {}
+
+    public TestClass4(int id, string name, string email, string other)
     {
         ID = id;
         Name = name;
@@ -47,95 +82,4 @@ public class TestClass
     public string Name { get; private set; }
     public string Email { get; private set; }
     public string Other { get; private set; }
-}
-
-public static class Extensions 
-{
-    public static TDestination TUseToConstruct<TDestination>(this object source) where TDestination : class
-    {
-        var sourceProperties = source.GetType().GetProperties().Select(p => p.GetValue(source)).ToArray();
-        
-        return (TDestination)Activator.CreateInstance(typeof(TDestination), sourceProperties);   
-    }
-
-    public static TDestination TUseToConstruct2<TDestination>(this object source) where TDestination: class
-    {
-        // Get all the constructors for the destination type
-        var constructors = typeof(TDestination).GetConstructors();
-        
-        var constructorSignatures = new Dictionary<ConstructorInfo, IEnumerable<string>>();
-        
-        // For each constructor on this type, add a dictionary entry where the constructor itself is the key, and the 
-        // value is a list of the parameters for the constructor, converted to strings in the form PROPNAME~TYPENAME
-        foreach (var constructor in constructors)
-        {
-            var constructorSignature = constructor.GetParameters().Select(p => string.Format("{0}~{1}", GetNormalisedPropertyName(p.Name), p.ParameterType));
-            
-            constructorSignatures.Add(constructor, constructorSignature);
-        }
-        
-        // Now we do the same with all the properties of the source type
-        var sourceProperties = source.GetType().GetProperties();
-
-        var sourcePropertySignature = sourceProperties.Select(p => string.Format("{0}~{1}", GetNormalisedPropertyName(p.Name), p.PropertyType));
-
-        // This dictionary will hold a number telling us how different each constructor signature
-        var rankedConstructorSignatures = new List<Tuple<ConstructorInfo, int>>();
-
-        // Loop over each constructor signature and find the one which matches the most source type properties, by intersecting
-        // the array of property signatures for each constructor with the property signature of the current source object
-        foreach (var k in constructorSignatures.Keys)
-            rankedConstructorSignatures.Add(new Tuple<ConstructorInfo, int>(k, sourcePropertySignature.Intersect(constructorSignatures[k]).Count()));
-        
-        // Pick the constructor with the largest intersection with the source type's properties
-        var bestConstructor = rankedConstructorSignatures.OrderByDescending(x => x.Item2).First().Item1;
-        
-        // Create a delegate which will construct on object of the new type using the best matching constructor
-        // TODO: We can also cache this in memory to improve performance
-        var createObject = CreateObject<TDestination>(bestConstructor);
-        
-        Func<PropertyInfo, ParameterInfo, bool> find = (sp, p) => GetNormalisedPropertyName(sp.Name) == GetNormalisedPropertyName(p.Name) && sp.PropertyType == p.ParameterType;
-        
-        var args = bestConstructor.GetParameters().Select(p => sourceProperties.FirstOrDefault(sp => find(sp, p))?.GetValue(source)).ToArray(); 
-        
-        return createObject(args);
-    }
-
-    private delegate T CreateT<T>(params object[] args);
-
-    private static CreateT<T> CreateObject<T>(ConstructorInfo ctor)
-    {
-        var type = ctor.DeclaringType;
-        var ctorParams = ctor.GetParameters();
-
-        //create a single param of type object[]
-        var args = Expression.Parameter(typeof(object[]), "args");
-
-        var argsExp = new Expression[ctorParams.Length];
-
-        //pick each arg from the params array 
-        //and create a typed expression of them
-        for (int i = 0; i < ctorParams.Length; i++)
-        {
-            argsExp[i] = Expression.Convert(
-                Expression.ArrayIndex(args, Expression.Constant(i)),
-                ctorParams[i].ParameterType
-            );
-        }
-
-        //make a NewExpression that calls the
-        //ctor with the args we just created
-        var newExp = Expression.New(ctor, argsExp);
-
-        //create a lambda with the New
-        //Expression as body and our param object[] as arg
-        var lambda = Expression.Lambda(typeof(CreateT<T>), newExp, args);
-
-        return (CreateT<T>)lambda.Compile();
-    }
-
-    private static string GetNormalisedPropertyName(string propertyName)
-    {
-        return Regex.Replace(propertyName.ToUpperInvariant(), "_", "");
-    }
 }


### PR DESCRIPTION
Normally, mapping works by creating an instance and then populating the property values; this works even if the properties have no public setters. However, this doesn't work if the destination type doesn't have a default constructor. This feature enables mapping to objects which have no default constructor.